### PR TITLE
Actualizar entrada de Aurgi: eliminar mención de prácticas

### DIFF
--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -197,11 +197,11 @@ import MapIcon from "./icons/MapIcon.astro";
       </h3>
       <p class="mt-1 text-lg font-medium text-gray-700 dark:text-gray-300">
         <span class="font-semibold text-gray-900 dark:text-white"
-          >Trainee Frontend Developer</span
+          >Frontend Developer</span
         >
       </p>
       <p class="mt-3 mb-4 text-xl font-normal text-gray-500 dark:text-gray-400">
-        En Aurgi realicé mis prácticas del Grado Superior, integrándome en el
+        En Aurgi formé parte del
         equipo de frontend. Colaboré en la mejora de componentes de la
         aplicación y fui responsable del <span
           class="dark:text-green-400 text-green-600">98%</span


### PR DESCRIPTION
Cambiado título de "Trainee Frontend Developer" a "Frontend Developer"
y reescrito la descripción para que aparezca como un trabajo normal.

https://claude.ai/code/session_01XpHgiJmdMNdC4PHeUj3o2M