### PR TITLE
Improve cursor label positioning and remove theme tooltip

### DIFF
--- a/src/components/Cursor.astro
+++ b/src/components/Cursor.astro
@@ -105,9 +105,6 @@
     left: 0;
     pointer-events: none;
     z-index: 9999;
-    display: flex;
-    align-items: center;
-    gap: 10px;
     opacity: 0;
     transform: translate3d(-100px, -100px, 0);
     will-change: transform;
@@ -116,6 +113,18 @@
   .cursor-shape {
     display: none;
     line-height: 0;
+  }
+
+  #custom-cursor-label {
+    position: absolute;
+    top: 50%;
+    left: calc(100% + 10px);
+    transform: translateY(-50%);
+  }
+
+  #custom-cursor.flip-label #custom-cursor-label {
+    left: auto;
+    right: calc(100% + 10px);
   }
 
   .cursor-shape svg {
@@ -210,6 +219,7 @@
         onScreen = true;
         updateVisibility();
       }
+      updateFlip();
     });
 
     document.addEventListener("mouseleave", () => {
@@ -217,9 +227,22 @@
       updateVisibility();
     });
 
+    const updateFlip = () => {
+      if (!cursor.classList.contains("has-label")) {
+        cursor.classList.remove("flip-label");
+        return;
+      }
+      const cursorRect = cursor.getBoundingClientRect();
+      const labelWidth = labelEl.offsetWidth;
+      const wouldOverflow =
+        cursorRect.right + 10 + labelWidth > window.innerWidth - 8;
+      cursor.classList.toggle("flip-label", wouldOverflow);
+    };
+
     const setLabel = (text: string) => {
       labelEl.textContent = text;
       cursor.classList.toggle("has-label", !!text);
+      updateFlip();
     };
 
     const getLabel = (el: HTMLElement): string => {

--- a/src/components/Theme.astro
+++ b/src/components/Theme.astro
@@ -3,7 +3,7 @@ import SunIcon from "./icons/Sun.astro";
 import MoonIcon from "./icons/Moon.astro";
 ---
 
-<div class="fixed top-4 right-4 md:top-6 md:right-6 z-50 group">
+<div class="fixed top-4 right-4 md:top-6 md:right-6 z-50">
   <button
     id="theme-toggle-btn"
     class="relative flex items-center justify-center size-10 border border-hairline bg-paper/70 backdrop-blur-sm text-ink hover:border-accent hover:text-accent transition-colors"
@@ -12,12 +12,6 @@ import MoonIcon from "./icons/Moon.astro";
     <SunIcon id="icon-sun" class="theme-toggle-icon size-4" />
     <MoonIcon id="icon-moon" class="theme-toggle-icon absolute size-4" />
   </button>
-  <span
-    role="tooltip"
-    class="pointer-events-none absolute right-full top-1/2 -translate-y-1/2 mr-2 whitespace-nowrap border border-hairline bg-paper/90 backdrop-blur-sm text-ink text-xs px-2 py-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
-  >
-    Cambiar tema
-  </span>
 </div>
 
 <script is:inline>


### PR DESCRIPTION
## Summary
This PR refactors the custom cursor label positioning logic to prevent overflow at viewport edges and removes the redundant tooltip from the theme toggle button.

## Key Changes

- **Cursor Label Positioning**: 
  - Removed flex layout from main cursor container and implemented absolute positioning for the label element
  - Added `updateFlip()` function that dynamically flips the label to the left side of the cursor when it would overflow the right edge of the viewport
  - Label now positions itself 10px to the right of the cursor by default, or 10px to the left when the `flip-label` class is applied
  - Flip logic is triggered on mouse move and when label text is set

- **Theme Toggle**: 
  - Removed the `group` class from the theme toggle container
  - Removed the tooltip span element that displayed "Cambiar tema" on hover, as this functionality is now handled by the custom cursor system

## Implementation Details
The cursor label now uses a smart positioning system that checks if the label would overflow the viewport width (with 8px margin) and automatically flips its position. This ensures better UX on smaller screens and near viewport edges.

https://claude.ai/code/session_01EoL9nNjzGKYW42M6zXJ35C